### PR TITLE
Add admin finance dashboard metrics and UI

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/api/tests/test_finanzas_admin.py
+++ b/backend/api/tests/test_finanzas_admin.py
@@ -1,0 +1,97 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from ..models import Condominio, Factura, Pago, Usuario, Vivienda
+
+
+class FinanzasAdminSummaryTests(APITestCase):
+    def setUp(self):
+        self.auth_user = User.objects.create_user(
+            username="admin", email="admin@example.com", password="pass1234"
+        )
+        self.usuario = Usuario.objects.create(user=self.auth_user)
+        self.client.force_authenticate(user=self.auth_user)
+
+        condominio = Condominio.objects.create(nombre="Condominio Central")
+        self.vivienda = Vivienda.objects.create(
+            condominio=condominio,
+            codigo_unidad="A-101",
+            bloque="A",
+            numero="101",
+        )
+
+        today = timezone.localdate()
+        self.current_period = today.strftime("%Y-%m")
+        previous_month_date = (today - timedelta(days=30))
+        self.previous_period = previous_month_date.strftime("%Y-%m")
+
+        self.factura_mes_pendiente = Factura.objects.create(
+            vivienda=self.vivienda,
+            periodo=self.current_period,
+            monto=Decimal("1500.00"),
+            estado="PENDIENTE",
+            fecha_vencimiento=today + timedelta(days=5),
+        )
+        self.factura_mes_pagada = Factura.objects.create(
+            vivienda=self.vivienda,
+            periodo=self.current_period,
+            monto=Decimal("800.00"),
+            estado="PAGADO",
+            fecha_vencimiento=today,
+        )
+        self.factura_vencida = Factura.objects.create(
+            vivienda=self.vivienda,
+            periodo=self.previous_period,
+            monto=Decimal("1000.00"),
+            estado="PENDIENTE",
+            fecha_vencimiento=today - timedelta(days=10),
+        )
+
+        Pago.objects.create(
+            factura=self.factura_mes_pagada,
+            metodo="transferencia",
+            monto_pagado=Decimal("800.00"),
+            estado="APROBADO",
+        )
+        pago_prev = Pago.objects.create(
+            factura=self.factura_vencida,
+            metodo="transferencia",
+            monto_pagado=Decimal("400.00"),
+            estado="APROBADO",
+        )
+        Pago.objects.filter(id=pago_prev.id).update(
+            fecha_pago=timezone.now() - timedelta(days=30)
+        )
+
+    def test_admin_summary_returns_expected_metrics(self):
+        response = self.client.get("/api/finanzas/admin/resumen/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertEqual(data["ingresos_mes"], "2300.00")
+        self.assertEqual(data["pagado_mes"], "800.00")
+        self.assertEqual(data["pendiente_mes"], "1500.00")
+        self.assertEqual(data["morosidad_total"], "1000.00")
+
+        facturas = data.get("facturas", {})
+        self.assertEqual(facturas.get("total_emitidas"), 3)
+        self.assertEqual(facturas.get("total_pagadas"), 1)
+        self.assertAlmostEqual(facturas.get("porcentaje_pagadas"), 33.33)
+
+        ingresos_mensuales = data.get("ingresos_mensuales", [])
+        self.assertEqual(len(ingresos_mensuales), 7)
+
+        current_period_entry = ingresos_mensuales[-1]
+        self.assertEqual(current_period_entry["periodo"], self.current_period)
+        self.assertAlmostEqual(float(current_period_entry["total"]), 800.0)
+
+        prev_period_entry = next(
+            (item for item in ingresos_mensuales if item["periodo"] == self.previous_period),
+            None,
+        )
+        self.assertIsNotNone(prev_period_entry)
+        self.assertAlmostEqual(float(prev_period_entry["total"]), 400.0)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -6,7 +6,12 @@ from .views import (
     VehiculoViewSet, AvisoViewSet, CondominioViewSet,
     recuperar_password, reset_password, perfil
 )
-from .finanzas.views import resumen_finanzas, lista_facturas, detalle_factura
+from .finanzas.views import (
+    resumen_finanzas,
+    lista_facturas,
+    detalle_factura,
+    resumen_finanzas_admin,
+)
 
 router = DefaultRouter()
 router.register(r'roles', RolViewSet)
@@ -23,6 +28,7 @@ urlpatterns = [
     path('reset-password/', reset_password),
     path('perfil/', perfil),
     path('finanzas/resumen/', resumen_finanzas),
+    path('finanzas/admin/resumen/', resumen_finanzas_admin),
     path('finanzas/facturas/', lista_facturas),
     path('finanzas/facturas/<uuid:pk>/', detalle_factura),
 ]

--- a/frontend-web/src/pages/Finanzas.css
+++ b/frontend-web/src/pages/Finanzas.css
@@ -1,0 +1,245 @@
+.finanzas-container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: linear-gradient(145deg, #f2f5f9, #d7dce8);
+  padding: 32px;
+  border-radius: 36px;
+  box-shadow: -16px -16px 32px #ffffff, 16px 16px 32px rgba(163, 177, 198, 0.65);
+  color: #1f2937;
+}
+
+.finanzas-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 1px;
+}
+
+.finanzas-header p {
+  margin: 4px 0 0;
+  color: #4a5568;
+}
+
+.finanzas-tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.finanzas-tab {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 28px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #5b6472;
+  background: linear-gradient(145deg, #f7faff, #d5dbe8);
+  box-shadow: -6px -6px 12px #ffffff, 6px 6px 12px rgba(163, 177, 198, 0.6);
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.finanzas-tab:hover,
+.finanzas-tab:focus-visible {
+  color: #1f2937;
+  box-shadow: -4px -4px 10px #ffffff, 4px 4px 10px rgba(163, 177, 198, 0.6);
+  outline: none;
+}
+
+.finanzas-tab.active {
+  color: #1f2937;
+  box-shadow: inset -6px -6px 12px #ffffff, inset 6px 6px 12px rgba(163, 177, 198, 0.6);
+}
+
+.finanzas-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.finanzas-loading,
+.finanzas-error,
+.finanzas-placeholder {
+  background: linear-gradient(145deg, #f7faff, #d5dbe8);
+  border-radius: 28px;
+  padding: 48px 32px;
+  text-align: center;
+  box-shadow: -12px -12px 24px #ffffff, 12px 12px 24px rgba(163, 177, 198, 0.5);
+  color: #2d3748;
+}
+
+.finanzas-error {
+  color: #b42318;
+}
+
+.finanzas-retry {
+  margin-top: 18px;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 26px;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(145deg, #5ad06b, #47b159);
+  cursor: pointer;
+  box-shadow: -4px -4px 10px rgba(255, 255, 255, 0.6), 4px 4px 12px rgba(91, 160, 110, 0.55);
+}
+
+.finanzas-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.finanzas-card {
+  background: linear-gradient(145deg, #f7faff, #d5dbe8);
+  border-radius: 28px;
+  padding: 24px;
+  box-shadow: -12px -12px 24px #ffffff, 12px 12px 24px rgba(163, 177, 198, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.finanzas-metric-title {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5b6472;
+}
+
+.finanzas-amount {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.finanzas-metric-subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.finanzas-bottom {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.finanzas-chart {
+  flex: 1;
+  min-width: 280px;
+}
+
+.finanzas-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.finanzas-chart-content {
+  display: flex;
+  align-items: flex-end;
+  gap: 20px;
+  height: 220px;
+  margin-top: 28px;
+  padding: 0 4px;
+}
+
+.finanzas-bar-column {
+  flex: 1;
+  min-width: 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.finanzas-bar {
+  width: 42px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #7ad86c, #49b558);
+  box-shadow: inset -6px -6px 10px rgba(255, 255, 255, 0.8), inset 6px 6px 12px rgba(70, 130, 90, 0.35);
+  transition: height 0.3s ease-in-out;
+}
+
+.finanzas-bar-value {
+  font-size: 0.85rem;
+  color: #4a5568;
+  font-weight: 600;
+}
+
+.finanzas-bar-label {
+  font-size: 0.8rem;
+  color: #4a5568;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.finanzas-progress {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-width: 240px;
+}
+
+.finanzas-progress-circle {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 16px auto;
+  position: relative;
+  box-shadow: -10px -10px 20px rgba(255, 255, 255, 0.6),
+    10px 10px 20px rgba(163, 177, 198, 0.6);
+}
+
+.finanzas-progress-circle::after {
+  content: "";
+  position: absolute;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #f7faff, #d5dbe8);
+  box-shadow: inset -8px -8px 16px #ffffff, inset 8px 8px 16px rgba(163, 177, 198, 0.55);
+}
+
+.finanzas-progress-value {
+  position: relative;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.finanzas-progress-details {
+  font-size: 0.95rem;
+  color: #4a5568;
+}
+
+.finanzas-placeholder h3 {
+  margin: 0 0 12px;
+  font-size: 1.4rem;
+}
+
+.finanzas-placeholder p {
+  margin: 0;
+  font-size: 1rem;
+  color: #4a5568;
+}
+
+@media (max-width: 768px) {
+  .finanzas-container {
+    padding: 24px;
+  }
+
+  .finanzas-progress-circle {
+    width: 160px;
+    height: 160px;
+  }
+
+  .finanzas-progress-circle::after {
+    width: 112px;
+    height: 112px;
+  }
+}

--- a/frontend-web/src/pages/Finanzas.js
+++ b/frontend-web/src/pages/Finanzas.js
@@ -1,11 +1,288 @@
-import React from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import API from "../api/axiosConfig";
+
+import "./Finanzas.css";
+
+const TABS = [
+  { id: "panel", label: "Panel" },
+  { id: "configuracion", label: "Configuración" },
+  { id: "facturas", label: "Facturas" },
+];
+
+const clampPercentage = (value) => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 100) {
+    return 100;
+  }
+  return value;
+};
 
 function Finanzas() {
-  return (
-    <div>
-      <h2>Finanzas</h2>
-      <p>Modulo pendiente. Aqui podras administrar pagos, cuotas y reportes economicos.</p>
+  const [activeTab, setActiveTab] = useState("panel");
+  const [summary, setSummary] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("es-BO", {
+        style: "currency",
+        currency: "BOB",
+        minimumFractionDigits: 2,
+      }),
+    []
+  );
+
+  const shortNumberFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("es-BO", {
+        maximumFractionDigits: 0,
+      }),
+    []
+  );
+
+  const formatCurrency = useCallback(
+    (value) => {
+      const numericValue = Number(value ?? 0);
+      if (Number.isNaN(numericValue)) {
+        return currencyFormatter.format(0);
+      }
+      return currencyFormatter.format(numericValue);
+    },
+    [currencyFormatter]
+  );
+
+  const formatShortCurrency = useCallback(
+    (value) => {
+      const numericValue = Number(value ?? 0);
+      if (Number.isNaN(numericValue) || numericValue === 0) {
+        return "Bs 0";
+      }
+      return `Bs ${shortNumberFormatter.format(numericValue)}`;
+    },
+    [shortNumberFormatter]
+  );
+
+  const loadSummary = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await API.get("finanzas/admin/resumen/");
+      setSummary(response.data);
+    } catch (err) {
+      const detail =
+        err?.response?.data?.detail ||
+        err?.response?.data?.error ||
+        "No se pudo cargar el resumen financiero.";
+      setError(detail);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  const metrics = useMemo(() => {
+    const parseNumber = (value) => {
+      const parsed = Number(value ?? 0);
+      return Number.isNaN(parsed) ? 0 : parsed;
+    };
+
+    const ingresosMensuales = Array.isArray(summary?.ingresos_mensuales)
+      ? summary.ingresos_mensuales.map((item) => ({
+          ...item,
+          totalNumber: parseNumber(item.total),
+        }))
+      : [];
+
+    const maxMonthlyTotal = ingresosMensuales.reduce(
+      (max, item) => Math.max(max, item.totalNumber),
+      0
+    );
+
+    return {
+      ingresosMes: parseNumber(summary?.ingresos_mes),
+      pagadoMes: parseNumber(summary?.pagado_mes),
+      pendienteMes: parseNumber(summary?.pendiente_mes),
+      morosidadTotal: parseNumber(summary?.morosidad_total),
+      ingresosMensuales,
+      ingresosMaximo: maxMonthlyTotal > 0 ? maxMonthlyTotal : 1,
+      facturasTotales: summary?.facturas?.total_emitidas || 0,
+      facturasPagadas: summary?.facturas?.total_pagadas || 0,
+      porcentajeFacturas: clampPercentage(
+        parseNumber(summary?.facturas?.porcentaje_pagadas)
+      ),
+    };
+  }, [summary]);
+
+  const renderPanel = () => {
+    if (loading) {
+      return (
+        <div className="finanzas-loading">
+          <p>Cargando resumen financiero...</p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="finanzas-error" role="alert">
+          <p>{error}</p>
+          <button type="button" onClick={loadSummary} className="finanzas-retry">
+            Reintentar
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <div className="finanzas-metrics">
+          <div className="finanzas-card">
+            <span className="finanzas-metric-title">Ingresos del mes</span>
+            <span className="finanzas-amount">
+              {formatCurrency(metrics.ingresosMes)}
+            </span>
+            <span className="finanzas-metric-subtitle">
+              Periodo actual estimado
+            </span>
+          </div>
+
+          <div className="finanzas-card">
+            <span className="finanzas-metric-title">Pagado del mes</span>
+            <span className="finanzas-amount">
+              {formatCurrency(metrics.pagadoMes)}
+            </span>
+            <span className="finanzas-metric-subtitle">
+              Pendiente: {formatCurrency(metrics.pendienteMes)}
+            </span>
+          </div>
+
+          <div className="finanzas-card">
+            <span className="finanzas-metric-title">Morosidad total</span>
+            <span className="finanzas-amount">
+              {formatCurrency(metrics.morosidadTotal)}
+            </span>
+            <span className="finanzas-metric-subtitle">
+              Facturas vencidas sin pagar
+            </span>
+          </div>
+        </div>
+
+        <div className="finanzas-bottom">
+          <div className="finanzas-card finanzas-chart">
+            <div className="finanzas-card-header">
+              <span className="finanzas-metric-title">Ingresos por mes</span>
+              <span className="finanzas-metric-subtitle">
+                Pagos confirmados por periodo
+              </span>
+            </div>
+            <div className="finanzas-chart-content" role="img" aria-label="Ingresos por mes">
+              {metrics.ingresosMensuales.map((item) => {
+                const percentage =
+                  metrics.ingresosMaximo === 0
+                    ? 0
+                    : Math.round((item.totalNumber / metrics.ingresosMaximo) * 100);
+                const barHeight = Math.max(percentage, item.totalNumber > 0 ? 8 : 2);
+
+                return (
+                  <div className="finanzas-bar-column" key={item.periodo}>
+                    <span className="finanzas-bar-value">
+                      {formatShortCurrency(item.totalNumber)}
+                    </span>
+                    <div
+                      className="finanzas-bar"
+                      style={{ height: `${barHeight}%` }}
+                      aria-hidden="true"
+                    />
+                    <span className="finanzas-bar-label">{item.label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="finanzas-card finanzas-progress">
+            <span className="finanzas-metric-title">Facturas pagadas total</span>
+            <div
+              className="finanzas-progress-circle"
+              style={{
+                background: `conic-gradient(#5ad06b ${
+                  metrics.porcentajeFacturas * 3.6
+                }deg, #d3dae6 0deg)`,
+              }}
+              role="img"
+              aria-label={`Facturas pagadas ${metrics.porcentajeFacturas}%`}
+            >
+              <span className="finanzas-progress-value">
+                {metrics.porcentajeFacturas.toFixed(0)}%
+              </span>
+            </div>
+            <div className="finanzas-progress-details">
+              <span>
+                {metrics.facturasPagadas} de {metrics.facturasTotales} facturas
+                pagadas
+              </span>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const renderPlaceholder = (label) => (
+    <div className="finanzas-placeholder">
+      <h3>{label}</h3>
+      <p>
+        Estamos preparando las herramientas para gestionar este módulo. Mientras
+        tanto puedes revisar el panel principal.
+      </p>
     </div>
+  );
+
+  return (
+    <section className="finanzas-container">
+      <header className="finanzas-header">
+        <h1>Finanzas</h1>
+        <p>Control centralizado de los ingresos y pagos del condominio.</p>
+      </header>
+
+      <div className="finanzas-tabs" role="tablist" aria-label="Modulos de finanzas">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={`finanzas-tab ${activeTab === tab.id ? "active" : ""}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="finanzas-content" role="tabpanel">
+        {activeTab === "panel"
+          ? renderPanel()
+          : renderPlaceholder(
+              activeTab === "configuracion" ? "Configuración" : "Facturas"
+            )}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- add an admin-level finance summary endpoint that aggregates monthly income, payments, arrears, and invoice completion metrics
- expose the new endpoint via the API router and cover it with an integration-style test fixture
- build the finance panel UI with neumorphic cards, monthly bar chart, and circular progress indicator styled to match the mobile experience

## Testing
- `python manage.py test` *(fails: database connection to Postgres is unavailable in the execution environment; sqlite fallback migrations also fail)*
- `CI=true npm test -- --watchAll=false` *(fails: existing Jest setup cannot resolve react-router-dom in this workspace)*

------
https://chatgpt.com/codex/tasks/task_b_68cd9bb112d8832ba69fb3dae83bdeb4